### PR TITLE
Remove object shorthand

### DIFF
--- a/src/charty.js
+++ b/src/charty.js
@@ -1345,11 +1345,11 @@ var Charty = (function () {
       update ? update(from) : A[name] = from
       animations[name] = {
         ease: ease || EASE.outQuad,
-        from,
-        to,
-        duration,
-        update,
-        cb
+        from: from,
+        to: to,
+        duration: duration,
+        update: update,
+        cb: cb
       }
     }
 


### PR DESCRIPTION
Shorthand properties are not available in pre-es2015 environments. By removing them, react-charty supports more environments.